### PR TITLE
Add logrotate config for rclone mount

### DIFF
--- a/snippets/rclone-gmedia-logrotate
+++ b/snippets/rclone-gmedia-logrotate
@@ -1,4 +1,6 @@
-<rclone-log-dir>/rclone-mount.log {
+<rclone-log-dir>/upload.log
+<rclone-log-dir>/rclone-mount.log
+{
 
   # Number of old log files to retain.
   rotate 10

--- a/snippets/rclone-mount-logrotate
+++ b/snippets/rclone-mount-logrotate
@@ -1,0 +1,20 @@
+<rclone-log-dir>/rclone-mount.log {
+
+  # Number of old log files to retain.
+  rotate 10
+
+  # DO NOT CHANGE. See manpage for info and https://github.com/rclone/rclone/issues/2259.
+  copytruncate
+
+  # Rotate log files once a day.
+  daily
+
+  # Disable gzip compression - Optional. See manpage for info.
+  nocompress
+
+  # No error if missing file.
+  missingok
+
+  # No rotate if file empty.
+  notifempty
+}


### PR DESCRIPTION
The rclone mount log can become very large over time since it is not rotated by default.
This config file can be used with the logrotate package to rotate the mount log once a day (by default).

Requirements:
* Place in `/etc/logrotate.d/` - e.g. `/etc/logrotate.d/rclone-gmedia-mount`
* Replace `<rclone-log-dir>` on line 1 with the path to your rclone log dir.