### PR TITLE
Add optional upload script

### DIFF
--- a/snippets/crontab
+++ b/snippets/crontab
@@ -1,1 +1,4 @@
 0 */6 * * * /usr/bin/rclone move <local-mountpoint> gdrive-media-crypt: --config /home/<youruser>/.config/rclone/rclone.conf --log-file <rclone-log-dir>/upload.log --log-level INFO --delete-empty-src-dirs --fast-list --min-age <min-age>
+
+# Optional: run script instead of directly calling rclone move
+# 0 */6 * * * /path/to/gmedia-upload.sh

--- a/snippets/gmedia-upload.sh
+++ b/snippets/gmedia-upload.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Stop script if error
+set -e
+
+# Set vars
+log='<rclone-log-dir>/upload.log'
+script=$(basename $0)
+date=$(date)
+
+# Print date header to log
+printf "\n\n############## $date ##############\n\n" >> $log
+
+# If script already running, print to log and exit
+if pidof -o %PPID -x "$script"
+then
+
+	printf 'Script already running. Exiting.' >> $log
+
+# Else rclone move
+else
+
+	/usr/bin/rclone move \
+		<local-mountpoint> gdrive-media-crypt: \
+		--config /home/<youruser>/.config/rclone/rclone.conf \
+		--log-file $log \
+		--log-level INFO \
+		--delete-empty-src-dirs \
+		--fast-list \
+		--min-age <min-age> \
+		--progress
+
+fi
+
+# Print end footer to log
+printf "\n############## Done ##############"


### PR DESCRIPTION
Script will operate as the existing cron entry does except
1. It will not allow more than one scheduled `rclone move` to run at once.
2. It will print a header with the date and footer to the log before/after each upload, making it slightly more readable.
3. It can be run manually and will print live progress to stdout.